### PR TITLE
Add check for body type

### DIFF
--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -42,7 +42,11 @@ const responseHandler = res =>
         return Promise.reject(Object.assign(err, errOpts));
       }
 
-      body._meta = buildMeta(res); // eslint-disable-line no-param-reassign
+      if(Array.isArray(body)) {
+        body[0]._meta = buildMeta(res);
+      } else {
+        body._meta = buildMeta(res); // eslint-disable-line no-param-reassign
+      }
 
       return body;
     });


### PR DESCRIPTION
I believe this is the least invasive method of resolving this. 

Simple requests like `/sites ` return in an array whereas requests on a collection like `/collections ` simply return an object. The array type responses prevent _meta object from getting appended to the response body. Even though the logic is written as if it should. By simply checking for the body type, we can reference the array index and append the buildMeta response to it.