### PR TITLE
Typescript definitions fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dist",
     "src",
     "LICENSE",
-    "yarn.lock"
+    "yarn.lock",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "BABEL_ENV=production babel --out-dir dist src/",


### PR DESCRIPTION
The `package.json` has a `files` list which limits which files `npm publish` will include in the published package. This PR adds the typescript definition file to that list.