### PR TITLE
`delete` method query params

### DIFF
--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -91,7 +91,7 @@ export default class Webflow {
   // Generic HTTP request handlers
 
   get(path, query = {}) {
-    return this.authenticatedFetch('GET', path, false, query);
+    return this.authenticatedFetch('GET', path, null, query);
   }
 
   post(path, data, query = {}) {
@@ -107,7 +107,7 @@ export default class Webflow {
   }
 
   delete(path, query = {}) {
-    return this.authenticatedFetch('DELETE', path, query);
+    return this.authenticatedFetch('DELETE', path, null, query);
   }
 
   // Meta


### PR DESCRIPTION
Query params for the `delete` method were getting passed as data. In the example below, observe `?live=true` does not get passed to the `delete` request.

```
const Webflow = require('webflow-api');

const api = new Webflow({ token: '<access_token>' });

const removed = api.removeItem({ collectionId: '<collection_id>', itemId: '<item_id>' }, { live: true })

removed.then(x => console.log(x));
```