### PR TITLE
feat: optional token through configuration flag

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -143,11 +143,17 @@ declare namespace Webflow {
   // helper types / namespaces
   type WebflowQueryArg = Record<string, any>;
 
-  interface WebflowOptions {
-    token: string;
-    endpoint?: string;
-    version?: string;
-  }
+  type WebflowOptions = {
+    token: string,
+    endpoint?: string,
+    version?: string,
+    handleAuthorization?: true,
+  } | {
+    token?: undefined,
+    endpoint?: string,
+    version?: string,
+    handleAuthorization: false,
+  };
 
   namespace WebflowApiModel {
     interface InfoApplication {

--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -52,8 +52,11 @@ export default class Webflow {
     endpoint = DEFAULT_ENDPOINT,
     token,
     version = '1.0.0',
+    handleAuthorization = true,
   } = {}) {
-    if (!token) throw buildRequiredArgError('token');
+    if (handleAuthorization && !token) {
+      throw buildRequiredArgError('token');
+    }
 
     this.responseWrapper = new ResponseWrapper(this);
 
@@ -62,7 +65,7 @@ export default class Webflow {
 
     this.headers = {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
+      ... handleAuthorization && { Authorization: `Bearer ${token}` },
       'accept-version': version,
       'Content-Type': 'application/json',
     };


### PR DESCRIPTION
Solves #56

## Description

Adds a flag (`handleAuthorization`) that allows the enables/disables authorization handling by the client, rendering the `token` property optional if set to `false`.