### PR TITLE
feat: make token as an optional parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ declare namespace Webflow {
   type WebflowQueryArg = Record<string, any>;
 
   interface WebflowOptions {
-    token: string;
+    token?: string;
     endpoint?: string;
     version?: string;
   }

--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -53,8 +53,6 @@ export default class Webflow {
     token,
     version = '1.0.0',
   } = {}) {
-    if (!token) throw buildRequiredArgError('token');
-
     this.responseWrapper = new ResponseWrapper(this);
 
     this.endpoint = endpoint;
@@ -62,7 +60,7 @@ export default class Webflow {
 
     this.headers = {
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
+      ...(token && { Authorization: `Bearer ${token}` }),
       'accept-version': version,
       'Content-Type': 'application/json',
     };

--- a/test.js
+++ b/test.js
@@ -3,16 +3,7 @@
 import nock from "nock";
 import test from "ava";
 
-import Webflow, { WebflowError } from "./dist";
-
-test("Requires an access token", (t) => {
-  t.throws(
-    () => {
-      new Webflow({}); // eslint-disable-line no-new
-    },
-    { instanceOf: WebflowError }
-  );
-});
+import Webflow from "./dist";
 
 test("Passes the access token as an HTTP header", (t) => {
   const scope = nock("https://api.webflow.com")


### PR DESCRIPTION
Solves #56

## Description

Allows Client users to optionally set the `token` configuration property. The `Authorization` header won't be populated if the token is undefined.