### PR TITLE
Allow CORS mode to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ const Webflow = require('webflow-api');
 // Initialize the API
 const api = new Webflow({ token: 'api-token' });
 
+// Initialize the API without CORS mode
+const apiNoCors = new Webflow({ token: 'api-token', fetchOpts: { mode: undefined }});
+
 // Fetch a site
 api.site({ siteId: '580e63e98c9a982ac9b8b741' }).then(site => console.log(site));
 ```
@@ -32,6 +35,7 @@ The `Webflow` constructor takes several options to initialize the API client:
 
 * `token` - the API token **(required)**
 * `version` - the version of the API you wish to use (optional)
+* `fetchOpts` - an option to override `fetch` options
 
 All of the API methods are documented in the [API documentation](https://developers.webflow.com).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,6 +178,7 @@ declare namespace Webflow {
     token: string;
     endpoint?: string;
     version?: string;
+    useCors?: boolean;
   }
 
   namespace WebflowApiModel {

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,7 +178,7 @@ declare namespace Webflow {
     token: string;
     endpoint?: string;
     version?: string;
-    useCors?: boolean;
+    fetchOpts?: RequestInit;
   }
 
   namespace WebflowApiModel {

--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -52,7 +52,7 @@ const responseHandler = (res) =>
     });
 
 export default class Webflow {
-  constructor({ endpoint = DEFAULT_ENDPOINT, token, version = "1.0.0" } = {}) {
+  constructor({ endpoint = DEFAULT_ENDPOINT, token, version = "1.0.0", useCors = true } = {}) {
     if (!token) throw buildRequiredArgError("token");
 
     this.responseWrapper = new ResponseWrapper(this);
@@ -75,8 +75,11 @@ export default class Webflow {
       const opts = {
         method,
         headers: this.headers,
-        mode: "cors",
       };
+
+      if (useCors) {
+        opts.mode = "cors";
+      }
 
       if (data) {
         opts.body = JSON.stringify(data);

--- a/src/Webflow.js
+++ b/src/Webflow.js
@@ -52,7 +52,7 @@ const responseHandler = (res) =>
     });
 
 export default class Webflow {
-  constructor({ endpoint = DEFAULT_ENDPOINT, token, version = "1.0.0", useCors = true } = {}) {
+  constructor({ endpoint = DEFAULT_ENDPOINT, token, version = "1.0.0", fetchOpts = {} } = {}) {
     if (!token) throw buildRequiredArgError("token");
 
     this.responseWrapper = new ResponseWrapper(this);
@@ -75,11 +75,9 @@ export default class Webflow {
       const opts = {
         method,
         headers: this.headers,
+        mode: "cors",
+        ...fetchOpts,
       };
-
-      if (useCors) {
-        opts.mode = "cors";
-      }
 
       if (data) {
         opts.body = JSON.stringify(data);


### PR DESCRIPTION
Hello! We are trying to use the Webflow API with Cloudflare Workers. Unfortunately, their fetch API does not allow the usage of `cors` mode. This seems to make sense, since there shouldn't be any cross-origin issues in a Node.JS environment, as there is no origin. However, I have added an optional parameter to the Webflow constructor (`useCors`) to ask if the user would like to use CORS or not. It defaults to `true` to make this a non-breaking change. I've also updated the TypeScript definition to match.