### PR TITLE
fixed oauth authorize url generation

### DIFF
--- a/src/api/oauth.ts
+++ b/src/api/oauth.ts
@@ -62,8 +62,9 @@ export class OAuth {
     if (state) params["state"] = state;
     if (scope) params["scope"] = scope;
 
+    const baseURL = client.defaults.baseURL.replace("api.", "");
     const url = "/oauth/authorize";
-    return client.getUri({ url, method: "GET", params });
+    return client.getUri({ baseURL, url, method: "GET", params });
   }
 
   /**

--- a/src/api/oauth.ts
+++ b/src/api/oauth.ts
@@ -62,9 +62,8 @@ export class OAuth {
     if (state) params["state"] = state;
     if (scope) params["scope"] = scope;
 
-    const baseURL = client.defaults.baseURL.replace("api.", "");
     const url = "/oauth/authorize";
-    return client.getUri({ baseURL, url, method: "GET", params });
+    return client.getUri({ url, method: "GET", params });
   }
 
   /**

--- a/tests/api/oauth.test.ts
+++ b/tests/api/oauth.test.ts
@@ -17,7 +17,7 @@ describe("OAuth", () => {
     const query = new URLSearchParams({ response_type, client_id, state });
 
     expect(url).toBeDefined();
-    expect(url).toBe(`${baseURL}/oauth/authorize?${query}`);
+    expect(url).toBe(`${baseURL.replace("api.", "")}/oauth/authorize?${query}`);
   });
 
   it("should generate an access token", async () => {

--- a/tests/api/oauth.test.ts
+++ b/tests/api/oauth.test.ts
@@ -1,7 +1,7 @@
 import MockAdapter from "axios-mock-adapter";
-import axios from "axios";
-import { OAuthFixture } from "../fixtures";
 import { OAuth } from "../../src/api";
+import { OAuthFixture } from "../fixtures";
+import axios from "axios";
 
 describe("OAuth", () => {
   const mock = new MockAdapter(axios);
@@ -17,7 +17,7 @@ describe("OAuth", () => {
     const query = new URLSearchParams({ response_type, client_id, state });
 
     expect(url).toBeDefined();
-    expect(url).toBe(`${baseURL}/oauth/authorize?${query}`);
+    expect(url).toBe(`${baseURL.replace("api.", "")}/oauth/authorize?${query}`);
   });
 
   it("should generate an access token", async () => {

--- a/tests/api/oauth.test.ts
+++ b/tests/api/oauth.test.ts
@@ -1,7 +1,7 @@
 import MockAdapter from "axios-mock-adapter";
-import { OAuth } from "../../src/api";
-import { OAuthFixture } from "../fixtures";
 import axios from "axios";
+import { OAuthFixture } from "../fixtures";
+import { OAuth } from "../../src/api";
 
 describe("OAuth", () => {
   const mock = new MockAdapter(axios);
@@ -17,7 +17,7 @@ describe("OAuth", () => {
     const query = new URLSearchParams({ response_type, client_id, state });
 
     expect(url).toBeDefined();
-    expect(url).toBe(`${baseURL.replace("api.", "")}/oauth/authorize?${query}`);
+    expect(url).toBe(`${baseURL}/oauth/authorize?${query}`);
   });
 
   it("should generate an access token", async () => {

--- a/tests/webflow.test.ts
+++ b/tests/webflow.test.ts
@@ -105,7 +105,7 @@ describe("Webflow", () => {
         const query = new URLSearchParams({ response_type, client_id, state });
 
         expect(url).toBeDefined();
-        expect(url).toBe(`https://api.${options.host}/oauth/authorize?${query}`);
+        expect(url).toBe(`https://${options.host}/oauth/authorize?${query}`);
       });
 
       it("should generate an access token", async () => {

--- a/tests/webflow.test.ts
+++ b/tests/webflow.test.ts
@@ -1,16 +1,15 @@
-import {
-  CollectionFixture,
-  ItemFixture,
-  MetaFixture,
-  OAuthFixture,
-  SiteFixture,
-  UserFixture,
-  WebhookFixture,
-} from "./fixtures";
-import { RequestError, Webflow } from "../src/core";
-
-import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { Webflow, RequestError } from "../src/core";
+import {
+  MetaFixture,
+  SiteFixture,
+  ItemFixture,
+  WebhookFixture,
+  CollectionFixture,
+  OAuthFixture,
+  UserFixture,
+} from "./fixtures";
 
 describe("Webflow", () => {
   const options = { host: "test.com", token: "test" };
@@ -106,7 +105,7 @@ describe("Webflow", () => {
         const query = new URLSearchParams({ response_type, client_id, state });
 
         expect(url).toBeDefined();
-        expect(url).toBe(`https://${options.host}/oauth/authorize?${query}`);
+        expect(url).toBe(`https://api.${options.host}/oauth/authorize?${query}`);
       });
 
       it("should generate an access token", async () => {

--- a/tests/webflow.test.ts
+++ b/tests/webflow.test.ts
@@ -1,15 +1,16 @@
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
-import { Webflow, RequestError } from "../src/core";
 import {
-  MetaFixture,
-  SiteFixture,
-  ItemFixture,
-  WebhookFixture,
   CollectionFixture,
+  ItemFixture,
+  MetaFixture,
   OAuthFixture,
+  SiteFixture,
   UserFixture,
+  WebhookFixture,
 } from "./fixtures";
+import { RequestError, Webflow } from "../src/core";
+
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
 
 describe("Webflow", () => {
   const options = { host: "test.com", token: "test" };
@@ -105,7 +106,7 @@ describe("Webflow", () => {
         const query = new URLSearchParams({ response_type, client_id, state });
 
         expect(url).toBeDefined();
-        expect(url).toBe(`https://api.${options.host}/oauth/authorize?${query}`);
+        expect(url).toBe(`https://${options.host}/oauth/authorize?${query}`);
       });
 
       it("should generate an access token", async () => {


### PR DESCRIPTION
The [webflow api documentation explicitly states](https://developers.webflow.com/docs/oauth#user-authorization), that the endpoint for the authorization url is `https://webflow.com/oauth/authorize` and not `https://api.webflow.com/oauth/authorize`.

- Corrected bug, where the generated authorization url started with api.webflow.com