### PR TITLE
Fix incorrect parameters in docs/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const authorizeUrl = WebflowClient.authorizeURL({
     state: "your_state",
     scope: "sites:read",
     clientId: "your_client_id",
-    redirctUri: "your_redirect_uri",
+    redirectUri: "your_redirect_uri",
 });
 
 console.log(authorizeUrl);


### PR DESCRIPTION
Fix typo in WebflowClient.authorizeURL params

``` js
const authorizeUrl = WebflowClient.authorizeURL({
    state: "your_state",
    scope: "sites:read",
    clientId: "your_client_id",
    redirctUri: "your_redirect_uri",  // --> rename to redirectUri
  });
```