### PR TITLE
Changed boolean create type to Switch as per the v2 documentation

### DIFF
--- a/src/api/resources/collections/resources/fields/types/FieldCreateType.ts
+++ b/src/api/resources/collections/resources/fields/types/FieldCreateType.ts
@@ -16,7 +16,7 @@ export type FieldCreateType =
     | "Phone"
     | "Number"
     | "DateTime"
-    | "Boolean"
+    | "Switch"
     | "Color"
     | "File";
 
@@ -31,7 +31,7 @@ export const FieldCreateType = {
     Phone: "Phone",
     Number: "Number",
     DateTime: "DateTime",
-    Boolean: "Boolean",
+    Switch: "Switch",
     Color: "Color",
     File: "File",
 } as const;

--- a/src/api/types/FieldType.ts
+++ b/src/api/types/FieldType.ts
@@ -16,7 +16,7 @@ export type FieldType =
     | "Phone"
     | "Number"
     | "DateTime"
-    | "Boolean"
+    | "Switch"
     | "Color"
     | "ExtFileRef";
 
@@ -31,7 +31,7 @@ export const FieldType = {
     Phone: "Phone",
     Number: "Number",
     DateTime: "DateTime",
-    Boolean: "Boolean",
+    Switch: "Switch",
     Color: "Color",
     ExtFileRef: "ExtFileRef",
 } as const;

--- a/src/serialization/resources/collections/resources/fields/types/FieldCreateType.ts
+++ b/src/serialization/resources/collections/resources/fields/types/FieldCreateType.ts
@@ -20,7 +20,7 @@ export const FieldCreateType: core.serialization.Schema<
     "Phone",
     "Number",
     "DateTime",
-    "Boolean",
+    "Switch",
     "Color",
     "File",
 ]);
@@ -37,7 +37,7 @@ export declare namespace FieldCreateType {
         | "Phone"
         | "Number"
         | "DateTime"
-        | "Boolean"
+        | "Switch"
         | "Color"
         | "File";
 }

--- a/src/serialization/types/FieldType.ts
+++ b/src/serialization/types/FieldType.ts
@@ -18,7 +18,7 @@ export const FieldType: core.serialization.Schema<serializers.FieldType.Raw, Web
         "Phone",
         "Number",
         "DateTime",
-        "Boolean",
+        "Switch",
         "Color",
         "ExtFileRef",
     ]);
@@ -35,7 +35,7 @@ export declare namespace FieldType {
         | "Phone"
         | "Number"
         | "DateTime"
-        | "Boolean"
+        | "Switch"
         | "Color"
         | "ExtFileRef";
 }


### PR DESCRIPTION
as mentioned on issue #143 unable to created Switch field. after some investigation found out schema validator does not have enum for `Switch`. I've replace `Boolean` type with `Switch` on all the necessary places