### PR TITLE
Fix manual wrapper API for getting Access Token

### DIFF
--- a/src/wrapper/WebflowClient.ts
+++ b/src/wrapper/WebflowClient.ts
@@ -81,6 +81,15 @@ export class WebflowClient extends FernClient {
             method: "POST",
             contentType: "application/json",
             body,
+            headers: {
+                "X-Fern-Language": "JavaScript",
+                "X-Fern-SDK-Name": "webflow-api",
+                "X-Fern-SDK-Version": "2.4.0",
+                "User-Agent": "webflow-api/2.4.0",
+                "X-Fern-Runtime": core.RUNTIME.type,
+                "X-Fern-Runtime-Version": core.RUNTIME.version,
+            },
+            requestType: "json",
         });
         if (response.ok) {
             return (response.body as any)["access_token"];


### PR DESCRIPTION
Small bug from the latest release.. the core fetcher might be expecting headers and/or requestType. This updated for all APIs except our manually maintained wrapper for `getAccessToken`. This should be the only other wrapper API we need to apply it to (the ItemsClient APIs are tested and have these headers)