### PR TITLE
CORE-1664 Replace d1otoma47x30pg.cloudfront.net with dev-assets.website-files.com

### DIFF
--- a/.mock/definition/assets.yml
+++ b/.mock/definition/assets.yml
@@ -168,7 +168,7 @@ service:
               assetUrl: >-
                 https://s3.amazonaws.com/webflow-prod-assets/6258612d1ee792848f805dcf/660d907ab9e91e3e9f56385e_paranoidAndroid-2024.png
               hostedUrl: >-
-                https://d1otoma47x30pg.cloudfront.net/643021114e290e0d3a0602b2/64358b9544249dc43d37d2b7_Screenshot%202023-04-11%20at%209.50.42%20AM.png
+                https://dev-assets.website-files.com/643021114e290e0d3a0602b2/64358b9544249dc43d37d2b7_Screenshot%202023-04-11%20at%209.50.42%20AM.png
               originalFileName: file.png
               createdOn: '2023-04-11T16:32:21Z'
               lastUpdated: '2023-04-12T20:31:03Z'

--- a/.mock/definition/orders.yml
+++ b/.mock/definition/orders.yml
@@ -151,7 +151,7 @@ service:
                       variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                       variantImage:
                         url: >-
-                          https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                          https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                       variantPrice:
                         unit: USD
                         value: '5892'
@@ -176,7 +176,7 @@ service:
                       variantSKU: incredible-bronze-towels-sleek-frozen-incredible-metal
                       variantImage:
                         url: >-
-                          https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e26729_image16.jpeg
+                          https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e26729_image16.jpeg
                       variantPrice:
                         unit: USD
                         value: '5892'
@@ -293,7 +293,7 @@ service:
                       variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                       variantImage:
                         url: >-
-                          https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                          https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                       variantPrice:
                         unit: USD
                         value: '5892'
@@ -320,7 +320,7 @@ service:
                         recycled-steel-gloves-electronic-granite-handcrafted-grey
                       variantImage:
                         url: >-
-                          https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                          https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                       variantPrice:
                         unit: USD
                         value: '5892'
@@ -516,7 +516,7 @@ service:
                   variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -539,7 +539,7 @@ service:
                   variantSKU: recycled-steel-gloves-electronic-granite-handcrafted-grey
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -750,7 +750,7 @@ service:
                   variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -773,7 +773,7 @@ service:
                   variantSKU: recycled-steel-gloves-electronic-granite-handcrafted-grey
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -974,7 +974,7 @@ service:
                   variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -997,7 +997,7 @@ service:
                   variantSKU: recycled-steel-gloves-electronic-granite-handcrafted-grey
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -1188,7 +1188,7 @@ service:
                   variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -1211,7 +1211,7 @@ service:
                   variantSKU: recycled-steel-gloves-electronic-granite-handcrafted-grey
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -1412,7 +1412,7 @@ service:
                   variantSKU: luxurious-fresh-ball-generic-bronze-practical-plastic
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2672c_image14.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'
@@ -1435,7 +1435,7 @@ service:
                   variantSKU: recycled-steel-gloves-electronic-granite-handcrafted-grey
                   variantImage:
                     url: >-
-                      https://d1otoma47x30pg.cloudfront.net/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
+                      https://dev-assets.website-files.com/66072f39417a2a35b2589cc7/66072fb51b89448912e2671e_image2.jpeg
                   variantPrice:
                     unit: USD
                     value: '5892'

--- a/.mock/definition/sites.yml
+++ b/.mock/definition/sites.yml
@@ -101,7 +101,7 @@ service:
                   lastPublished: '2023-04-02T12:42:00Z'
                   lastUpdated: '2016-10-24T19:43:17Z'
                   previewUrl: >-
-                    https://d1otoma47x30pg.cloudfront.net/42e63e98c9a982ac9b8b741/197910121200.png
+                    https://dev-assets.website-files.com/42e63e98c9a982ac9b8b741/197910121200.png
                   timeZone: DeepSpace/InfiniteImprobability
                   parentFolderId: 1as2d3f4g5h6j7k8l9z0x1c2v3b4n5m6
                   customDomains:
@@ -142,7 +142,7 @@ service:
                   lastPublished: '2023-04-02T12:45:00Z'
                   lastUpdated: '2016-10-24T19:43:17Z'
                   previewUrl: >-
-                    https://d1otoma47x30pg.cloudfront.net/42e63e98c9a982ac9b8b742/198110121200.png
+                    https://dev-assets.website-files.com/42e63e98c9a982ac9b8b742/198110121200.png
                   timeZone: DeepSpace/Depression
                   customDomains:
                     - id: 589a331aa51e760df7ccb89f
@@ -175,7 +175,7 @@ service:
                   lastPublished: '2023-04-02T12:50:00Z'
                   lastUpdated: '2016-10-24T19:43:17Z'
                   previewUrl: >-
-                    https://d1otoma47x30pg.cloudfront.net/42e63e98c9a982ac9b8b743/198210121200.png
+                    https://dev-assets.website-files.com/42e63e98c9a982ac9b8b743/198210121200.png
                   timeZone: Vogsphere/PoetryHall
                   customDomains:
                     - id: 589a331aa51e760df7ccb8a0


### PR DESCRIPTION
[CORE-1664](https://webflow.atlassian.net/browse/CORE-1664)

This is part of effort of migration from Cloudfront to Cloudflare. New cdn `dev-assets.website-files.com` redirects to same S3 bucket backed endpoint as `d1otoma47x30pg.cloudfront.net`.

###Tests

`dev-assets.website-files.com` is tested out redirecting to S3 origin `webflow-dev-assets.s3.amazonaws.com`.

[CORE-1664]: https://webflow.atlassian.net/browse/CORE-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ