### PR TITLE
[APPSEC] Remove redundant SOCKET_SECURITY_API_KEY env var from Socket scan workflow

### DIFF
--- a/.github/workflows/socket_reachability.yml
+++ b/.github/workflows/socket_reachability.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Run Socket Security Scan
         env:
-          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           SOCKET_SECURITY_API_TOKEN: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           PYTHONUNBUFFERED: "1"
           ENABLE_REACH: ${{ github.event.inputs.enable_reachability }}


### PR DESCRIPTION
## Summary
- Removes the redundant `SOCKET_SECURITY_API_KEY` env var from the Socket Security Scan workflow
- Keeps only `SOCKET_SECURITY_API_TOKEN`, which is the correct env var used by the Socket CLI

## Test plan
- [ ] After merge, manually trigger the workflow via the "Run workflow" button to confirm it runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)